### PR TITLE
Transaction Updates

### DIFF
--- a/Sources/Mercato/Mercato.swift
+++ b/Sources/Mercato/Mercato.swift
@@ -105,6 +105,7 @@ extension Mercato
         shared.listenForUnfinishedTransactions(updateBlock: updateBlock)
     }
     
+    /// Any unfinished transactions will be emitted when you first iterate the sequence.
     public static func listenForTransactionUpdates(updateBlock: @escaping TransactionUpdate)
     {
         shared.listenForTransactionUpdates(updateBlock: updateBlock)


### PR DESCRIPTION
Xcode throws an following warning if try to make a purchase without listening to transaction updates. This PR introduces a same function with the existing one but listening to `updates` sequence so the client can play with it.
![Screenshot 2023-08-31 at 9 15 23 AM](https://github.com/dapperlabs/Mercato/assets/947537/b6afe081-fc31-41ca-a0df-01e135e4b2ff)
